### PR TITLE
Added config page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage
 
 # nyc test coverage
 .nyc_output
+/test/e2e/reports
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ typings/
 
 # next.js build output
 .next
+
+# Build result
+/dist
+
+# Optional application configuration:
+/static/config.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -5127,7 +5127,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5148,12 +5149,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5168,17 +5171,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5295,7 +5301,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5307,6 +5314,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5321,6 +5329,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5328,12 +5337,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5352,6 +5363,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5432,7 +5444,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5444,6 +5457,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5529,7 +5543,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5565,6 +5580,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5584,6 +5600,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5627,12 +5644,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,15 @@
 <template>
   <div id="app">
-    <header>
-      <span>Vue.js PWA</span>
-    </header>
-    <main>
-      <img src="./assets/logo.png" alt="Vue.js PWA">
+    <b-navbar toggleable="md" type="dark" variant="dark">
+      <b-navbar-toggle target="nav_collapse"></b-navbar-toggle>
+      <b-navbar-brand to="/">Gingerbread</b-navbar-brand>
+      <b-collapse is-nav id="nav_collapse">
+        <b-navbar-nav>
+          <b-nav-item to="/config">Config</b-nav-item>
+        </b-navbar-nav>
+      </b-collapse>
+    </b-navbar>
+    <main role="main" class="container">
       <router-view></router-view>
     </main>
   </div>
@@ -17,38 +22,4 @@ export default {
 </script>
 
 <style>
-body {
-  margin: 0;
-}
-
-#app {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  color: #2c3e50;
-}
-
-main {
-  text-align: center;
-  margin-top: 40px;
-}
-
-header {
-  margin: 0;
-  height: 56px;
-  padding: 0 16px 0 24px;
-  background-color: #35495E;
-  color: #ffffff;
-}
-
-header span {
-  display: block;
-  position: relative;
-  font-size: 20px;
-  line-height: 1;
-  letter-spacing: .02em;
-  font-weight: 400;
-  box-sizing: border-box;
-  padding-top: 16px;
-}
 </style>

--- a/src/components/Config.vue
+++ b/src/components/Config.vue
@@ -1,0 +1,69 @@
+<template>
+  <div class="config row">
+    <div class="col-md-12">
+      <b-form>
+        <b-form-group label="Name" label-for="config-name">
+          <b-form-input id="config-name" type="text" v-model="form.name" :disabled="true"></b-form-input>
+        </b-form-group>
+        <b-form-group label="Fee %" label-for="config-fee-percent">
+          <b-form-input id="config-fee-percent" type="number" v-model="form.fee_percent" :disabled="true"></b-form-input>
+        </b-form-group>
+        <b-form-group label="Minimum contribution" label-for="config-minimum-contribution">
+          <b-form-input id="config-minimum-contribution" type="number" v-model="form.minimum_contribution" :disabled="true"></b-form-input>
+        </b-form-group>
+        <b-form-group label="Tezos RPC address" label-for="config-tezos-rpc-address">
+          <b-form-input id="config-tezos-rpc-address" type="text" v-model="form.tezos_rpc_address" :disabled="true"></b-form-input>
+        </b-form-group>
+        <b-form-group label="Baker Tz address" label-for="config-baker-tz-address">
+          <b-form-input id="config-baker-tz-address" type="text" v-model="form.baker_tz_address" :disabled="true"></b-form-input>
+        </b-form-group>
+      </b-form>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'hello',
+  data () {
+    return {
+      form: {
+        name: null,
+        fee_percent: null,
+        minimum_contribution: null,
+        tezos_rpc_address: null,
+        baker_tz_address: null
+      }
+    }
+  },
+  created () {
+    this.loadConfig()
+  },
+  methods: {
+    loadDefaultConfig () {
+      console.log('No /static/config.json found; using default config.')
+      this.form = {
+        name: 'foo',
+        fee_percent: 5,
+        minimum_contribution: 3,
+        tezos_rpc_address: 'asdf',
+        baker_tz_address: 'asdf'
+      }
+    },
+    loadConfig () {
+      fetch('/static/config.json')
+        .then((resp) => {
+          if (resp.ok) resp.json().then((j) => { this.form = j })
+          else this.loadDefaultConfig()
+        })
+        .catch(() => {
+          this.loadDefaultConfig()
+        })
+    }
+  }
+}
+</script>
+
+<!-- Add "scoped" attribute to limit CSS to this component only -->
+<style>
+</style>

--- a/src/components/Hello.vue
+++ b/src/components/Hello.vue
@@ -1,21 +1,25 @@
 <template>
-  <div class="hello">
-    <h1>{{ msg }}</h1>
-    <h2>Essential Links</h2>
-    <ul>
-      <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
-      <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
-      <li><a href="http://chat.vuejs.org/" target="_blank" rel="noopener">Vue Community Chat</a></li>
-      <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
-      <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank" rel="noopener">Docs for This Template</a></li>
-    </ul>
-    <h2>Ecosystem</h2>
-    <ul>
-      <li><a href="http://router.vuejs.org/" target="_blank" rel="noopener">vue-router</a></li>
-      <li><a href="http://vuex.vuejs.org/" target="_blank" rel="noopener">vuex</a></li>
-      <li><a href="http://vue-loader.vuejs.org/" target="_blank" rel="noopener">vue-loader</a></li>
-      <li><a href="https://github.com/vuejs/awesome-vue" target="_blank" rel="noopener">awesome-vue</a></li>
-    </ul>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="hello">
+        <h1>{{ msg }}</h1>
+        <h2>Essential Links</h2>
+        <ul>
+          <li><a href="https://vuejs.org" target="_blank" rel="noopener">Core Docs</a></li>
+          <li><a href="https://forum.vuejs.org" target="_blank" rel="noopener">Forum</a></li>
+          <li><a href="http://chat.vuejs.org/" target="_blank" rel="noopener">Vue Community Chat</a></li>
+          <li><a href="https://twitter.com/vuejs" target="_blank" rel="noopener">Twitter</a></li>
+          <li><a href="http://vuejs-templates.github.io/webpack/" target="_blank" rel="noopener">Docs for This Template</a></li>
+        </ul>
+        <h2>Ecosystem</h2>
+        <ul>
+          <li><a href="http://router.vuejs.org/" target="_blank" rel="noopener">vue-router</a></li>
+          <li><a href="http://vuex.vuejs.org/" target="_blank" rel="noopener">vuex</a></li>
+          <li><a href="http://vue-loader.vuejs.org/" target="_blank" rel="noopener">vue-loader</a></li>
+          <li><a href="https://github.com/vuejs/awesome-vue" target="_blank" rel="noopener">awesome-vue</a></li>
+        </ul>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -32,21 +36,4 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style>
-h1, h2 {
-  font-weight: normal;
-}
-
-ul {
-  list-style-type: none;
-  padding: 0;
-}
-
-li {
-  display: inline-block;
-  margin: 0 10px;
-}
-
-a {
-  color: #35495E;
-}
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@ import Vue from 'vue'
 import App from './App'
 import router from './router'
 import BootstrapVue from 'bootstrap-vue'
+import 'bootstrap/dist/css/bootstrap.css'
+import 'bootstrap-vue/dist/bootstrap-vue.css'
 
 Vue.use(BootstrapVue)
 Vue.config.productionTip = false

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import Router from 'vue-router'
 import Hello from '@/components/Hello'
+import Config from '@/components/Config'
 
 Vue.use(Router)
 
@@ -10,6 +11,11 @@ export default new Router({
       path: '/',
       name: 'Hello',
       component: Hello
+    },
+    {
+      path: '/config',
+      name: 'Config',
+      component: Config
     }
   ]
 })


### PR DESCRIPTION
This builds on my first PR. Here I:

- Removed Vue styling and placeholder text.
- Use Bootstrap-Vue to style the top nav etc.
- Use Vue-Router for top nav links.
- Added `/config` route to show readonly config info.
- Load config from `/static/config.json` if present, with fallback to some hard-coded defaults. (You should choose/suggest better ones.)

Note I'm loading the file from `/static/config.json` instead of just `/config.json` because that's how webpack is set up to serve static files, and I assume it's just a placeholder anyway until we have a backend, so I didn't want to put time into changing the webpack configuration. Also a top-level `config.json` is interpreted by the build process to be build configuration, not just an ordinary file to serve. If putting it in `static` is a problem let me know though!
